### PR TITLE
chap09 likelihood fix

### DIFF
--- a/09_unsupervised_learning.ipynb
+++ b/09_unsupervised_learning.ipynb
@@ -4750,7 +4750,7 @@
     "ss = np.linspace(1, 2, 101)\n",
     "XX, SS = np.meshgrid(xx, ss)\n",
     "ZZ = 2 * norm.pdf(XX - 1.0, 0, SS) + norm.pdf(XX + 4.0, 0, SS)\n",
-    "ZZ = ZZ / ZZ.sum(axis=1) / (xx[1] - xx[0])"
+    "ZZ = ZZ / ZZ.sum(axis=1)[:,np.newaxis] / (xx[1] - xx[0])"
    ]
   },
   {


### PR DESCRIPTION
We're missing `[:,np.newaxis]`.
With the faulty code, the sums are broadcasted along the theta axis instead of the x axis. As a consequence the sum of the normalized densities for a given theta is not 1.

It worked by chance because we have the same dimension for the theta axis and the x axis (both 101). But if you replace 101 with e.g. 20 for one of the dimensions, we get a numpy error.

The symptom is unnoticeable in the book's picture.
BTW kudos for your fantastic book.