### PR TITLE
Update Dockerfile to use requirements.txt

### DIFF
--- a/docker/Dockerfile
+++ b/docker/Dockerfile
@@ -6,9 +6,18 @@ RUN apt-get update && apt-get upgrade -y \
         build-essential \
         git \
         sudo \
-        cmake zlib1g-dev libjpeg-dev xvfb libav-tools xorg-dev libboost-all-dev libsdl2-dev swig \
-        unzip zip \
-    && rm -rf /var/lib/apt/lists/*
+        cmake \
+        zlib1g-dev \
+        libjpeg-dev \
+        xvfb \
+        libav-tools \
+        xorg-dev \
+        libboost-all-dev \
+        libsdl2-dev \
+        swig \
+        unzip \
+        zip \
+     && rm -rf /var/lib/apt/lists/*
 
 RUN conda update -n base conda
 RUN conda install -y \
@@ -17,21 +26,12 @@ RUN conda install -y \
 RUN conda install -y -c conda-forge \
         pyopengl \
         xgboost \
-        nbdime
-RUN pip install "urlextract"
-RUN pip install "gym[atari,box2d,classic_control]"
-RUN pip install "tensorflow-hub"
-RUN pip install "tensorflow-serving-api"
-RUN pip install "tfx"
-#RUN pip install "tensorflow-addons"
-RUN pip install "tf-agents-nightly"
-RUN pip install "tfds-nightly"
-RUN pip install "tfp-nightly"
-RUN pip uninstall -y tensorflow
-RUN pip uninstall -y tensorboard
-RUN pip install "tf-nightly-2.0-preview"
-RUN pip install "tb-nightly"
+        nbdime \
+        nodejs \
+        ipywidgets
 
+COPY requirements.txt /tmp/
+RUN pip install --upgrade -r /tmp/requirements.txt
 
 ARG username
 ARG userid
@@ -69,7 +69,6 @@ COPY docker/bashrc.bash /tmp/
 RUN cat /tmp/bashrc.bash >> ${home}/.bashrc
 RUN echo "export PATH=\"${workdir}/docker/bin:$PATH\"" >> ${home}/.bashrc
 RUN sudo rm /tmp/bashrc.bash
-
 
 # INFO: Uncomment lines below to enable automatic save of python-only and html-only
 #       exports alongside the notebook

--- a/docker/Makefile
+++ b/docker/Makefile
@@ -2,13 +2,13 @@
 help:
 	cat Makefile
 run:
-	docker-compose up
+	docker-compose up --build
 exec:
 	docker-compose exec handson-ml2 bash
 build: stop .FORCE
 	docker-compose build
 rebuild: stop .FORCE
-	docker-compose build --force-rm
+	docker-compose up --build
 stop:
-	docker stop handson-ml2 || true; docker rm handson-ml2 || true;
+	docker-compose down || true;
 .FORCE:

--- a/docker/Makefile
+++ b/docker/Makefile
@@ -8,7 +8,7 @@ exec:
 build: stop .FORCE
 	docker-compose build
 rebuild: stop .FORCE
-	docker-compose up --build
+	docker-compose build --force-rm
 stop:
 	docker-compose down || true;
 .FORCE:

--- a/requirements.txt
+++ b/requirements.txt
@@ -41,18 +41,10 @@ xgboost==0.82
 
 ##### TensorFlow-related packages
 
-# Replace tensorflow with tensorflow-gpu if you want GPU support. If so,
-# you need a GPU card with CUDA Compute Capability 3.5 or higher support, and
-# you must install CUDA, cuDNN and more: see tensorflow.org for the detailed
-# installation instructions.
+tensorflow~=2.0.0-rc1
+tensorboard~=2.0.0
 
-tf-nightly-2.0-preview
-#tf-nightly-gpu-2.0-preview
-
-#tensorboard
-tb-nightly
-
-#tensorflow-datasets
+# tensorflow-datasets
 tfds-nightly
 
 tensorflow-hub
@@ -69,7 +61,7 @@ tensorflow-hub
 tf-agents-nightly
 
 # Optional: the TF Serving API library is just needed for chapter 19.
-tensorflow-serving-api
+# tensorflow-serving-api
 
 
 ##### Image manipulation
@@ -83,7 +75,8 @@ scikit-image==0.14.2
 # OpenAI gym is only needed in chapter 18.
 # There are a few dependencies you need to install first, check out:
 # https://github.com/openai/gym#installing-everything
-gym[atari]==0.10.9
+# gym[atari]==0.10.9
+gym[atari,box2d,classic_control]==0.10.9
 
 
 ##### Additional utilities
@@ -109,3 +102,13 @@ requests==2.22.0
 tqdm==4.31.1
 ipywidgets==7.4.2
 
+# tmp fix for peer dependency error:
+# spyder 3.3.3 requires pyqt5<=5.12; python_version >= "3", which is not installed.
+# tfp-nightly 0.9.0.dev20190926 has requirement cloudpickle==1.1.1, but you'll have cloudpickle 0.8.0 which is incompatible.
+cloudpickle~=1.1.0
+
+# tmp fix for peer dep error:
+# Successfully built gym nltk opt-einsum absl-py termcolor gast promise dill googleapis-common-protos
+# spyder 3.3.3 requires pyqt5<=5.12; python_version >= "3", which is not installed.
+pyqt5<=5.12
+python_version >= "3"


### PR DESCRIPTION
- Remove dep drift between Dockerfile pip install and requirements.txt pip install
- Prevent Makefile from deleting container images when running `make <stop|build|run>`
- Leave `make rebuild` as is. It's the nuclear option
  - [ ] Document this. You rarely need this when using docker correctly
- Changing requirements.txt then running `make run` takes ~2 minutes vs 20 min
  (macbook pro, 2018) via proper use of intermediate docker layers
- add nodejs (to enable jupyter-lab at `/lab`)
- use tensorflow~=2.0.0-rc1 to allow semver patch drift
- ensure pip install does not output errors via the following tmp hack:

    ```
    # tmp fix for peer dependency error:
    # spyder 3.3.3 requires pyqt5<=5.12; python_version >= "3", which is not installed.
    # tfp-nightly 0.9.0.dev20190926 has requirement cloudpickle==1.1.1, but you'll have cloudpickle 0.8.0 which is incompatible.
    cloudpickle~=1.1.0

    # tmp fix for peer dep error:
    # Successfully built gym nltk opt-einsum absl-py termcolor gast promise dill googleapis-common-protos
    # spyder 3.3.3 requires pyqt5<=5.12; python_version >= "3", which is not installed.
    pyqt5<=5.12
    python_version >= "3"
    ```

These changes are not the end all, but they do allow for future changes
w/ minimal room for human error and faster docker build times. This pr is
thus meant to enable easier iteration when changing upstream deps.

Note: inspiration and initial idea came from pr #30. This PR aims to address comments in that pr && improve docker build performance when using the Makefile commands && reduce duplication of dependency lists between Dockerfile and requirements.txt

PS: python is my nth language and package management is my weakest skill in python atm, please review carefully.