### PR TITLE
[Chapter 2] Fix colorbar ticks 

### DIFF
--- a/02_end_to_end_machine_learning_project.ipynb
+++ b/02_end_to_end_machine_learning_project.ipynb
@@ -1461,7 +1461,7 @@
     "\n",
     "prices = housing[\"median_house_value\"]\n",
     "tick_values = np.linspace(prices.min(), prices.max(), 11)\n",
-    "cbar = plt.colorbar()\n",
+    "cbar = plt.colorbar(ticks=tick_values/prices.max())\n",
     "cbar.ax.set_yticklabels([\"$%dk\"%(round(v/1000)) for v in tick_values], fontsize=14)\n",
     "cbar.set_label('Median House Value', fontsize=16)\n",
     "\n",


### PR DESCRIPTION
Hi Aurelien, 

Scatter plot over the California image gives wrong yticks. It ranges 0k~306k.
It's because colorbar() set ticks automatically.
So `ticks` parameter need to set for proper range.
I didn't rerun this notebook, because the diff is overwhelming. :)

![Scatter plot over the California image](https://user-images.githubusercontent.com/18256853/81462193-b21fec00-91eb-11ea-9749-e5a2909878c7.png)

Thanks.