### PR TITLE
Fixed

### DIFF
--- a/04_training_linear_models.ipynb
+++ b/04_training_linear_models.ipynb
@@ -667,7 +667,7 @@
     "\n",
     "t = 0\n",
     "for epoch in range(n_iterations):\n",
-    "    shuffled_indices = np.random.permutation(m)\n",
+    "    shuffled_indices = np.random.permutation(epoch)\n",
     "    X_b_shuffled = X_b[shuffled_indices]\n",
     "    y_shuffled = y[shuffled_indices]\n",
     "    for i in range(0, m, minibatch_size):\n",


### PR DESCRIPTION
In Mini-batch Gradient Descent algorithm, for epoch permutation use epoch instead of m as its parameter.