### PR TITLE
Change rebuild target

### DIFF
--- a/docker/Makefile
+++ b/docker/Makefile
@@ -8,7 +8,7 @@ exec:
 build: stop .FORCE
 	docker-compose build
 rebuild: stop .FORCE
-	docker-compose build --force-rm
+	docker-compose build --no-cache
 stop:
 	docker stop handson-ml2 || true; docker rm handson-ml2 || true;
 .FORCE:


### PR DESCRIPTION
* This PR adds `--no-cache` to `docker-compose build` when `make rebuild` is ran.<br>Otherwise it doesn't rebuild from scratch. This is preferred because the contents of `continuumio/miniconda3:latest` will change from time to time. (And probably even more often than the contents of our `Dockerfile`)
* `--force-rm` is not needed because `make rebuild` will already remove the container because it calls the stop target with `stop .FORCE` (which removes the container)