### PR TITLE
Bump TensorFlow to 2.1.2 and Pillow to 7.1.0 or later to patch vulnerabilities.

### DIFF
--- a/requirements.txt
+++ b/requirements.txt
@@ -61,7 +61,7 @@ tf-agents==0.3.0
 
 ##### Image manipulation
 imageio==2.6.1
-Pillow==7.0.0
+Pillow>=7.1.0
 scikit-image==0.16.2
 graphviz==0.13.2
 pydot==1.4.1


### PR DESCRIPTION
Bump TensorFlow from 2.1.0 to 2.1.2 as a patch for vulnerabilities covered [here](https://github.com/tensorflow/tensorflow/releases/tag/v2.1.2)
Bump Pillow from 7.0.0 to 7.1.0 or later as a patch for these vulnerabilities: CVE-2020-10379, CVE-2020-10177, CVE-2020-10994, CVE-2020-11538.