### PR TITLE
Update 01_the_machine_learning_landscape.ipynb

### DIFF
--- a/01_the_machine_learning_landscape.ipynb
+++ b/01_the_machine_learning_landscape.ipynb
@@ -133,7 +133,7 @@
    ],
    "source": [
     "# Download the data\n",
-    "import urllib\n",
+    "import urllib.request\n",
     "DOWNLOAD_ROOT = \"https://raw.githubusercontent.com/ageron/handson-ml2/master/\"\n",
     "os.makedirs(datapath, exist_ok=True)\n",
     "for filename in (\"oecd_bli_2015.csv\", \"gdp_per_capita.csv\"):\n",


### PR DESCRIPTION
seems that new python libs used by google colab need „import urlib.request“ instead of „import urllib“:

error report with the original file:
Downloading oecd_bli_2015.csv
---------------------------------------------------------------------------
AttributeError                            Traceback (most recent call last)
<ipython-input-16-dc3c625f5638> in <module>()
      6     print("Downloading", filename)
      7     url = DOWNLOAD_ROOT + "datasets/lifesat/" + filename
----> 8     urllib.request.urlretrieve(url, datapath + filename)

AttributeError: module 'urllib' has no attribute 'request'