### PR TITLE
Fixed misspelling of 'literature'

### DIFF
--- a/math_differential_calculus.ipynb
+++ b/math_differential_calculus.ipynb
@@ -2328,7 +2328,7 @@
     "id": "Zu6u_8bw7ZUc"
    },
    "source": [
-    "A word about notations: there are several other notations for the derivative that you will find in the litterature:\n",
+    "A word about notations: there are several other notations for the derivative that you will find in the literature:\n",
     "\n",
     "$f'(x) = \\dfrac{\\mathrm{d}f(x)}{\\mathrm{d}x} = \\dfrac{\\mathrm{d}}{\\mathrm{d}x}f(x)$\n",
     "\n",
@@ -5994,15 +5994,15 @@
    "name": "python",
    "nbconvert_exporter": "python",
    "pygments_lexer": "ipython3",
-   "version": "3.7.6"
+   "version": "3.6.1"
   },
   "pycharm": {
    "stem_cell": {
     "cell_type": "raw",
-    "source": [],
     "metadata": {
      "collapsed": false
-    }
+    },
+    "source": []
    }
   }
  },


### PR DESCRIPTION
"Literature" was misspelled as "litterature" in the calculus notebook. This is a fix for that typo.