### PR TITLE
Reorganisation of repository dependencies

### DIFF
--- a/environment.yml
+++ b/environment.yml
@@ -3,55 +3,22 @@ channels:
   - conda-forge
   - defaults
 dependencies:
-  - graphviz
+  - gast==0.2.2
   - imageio=2.6
   - ipython=7.12
-  - ipywidgets=7.5
-  - joblib=0.14
-  - jupyter=1.0
-  - matplotlib=3.1
-  - nbdime=2.0
-  - nltk=3.4
-  - numexpr=2.7
-  - numpy=1.18
-  - pandas=1.0
+  - ipywidgets==7.5.1
   - pillow=7.0
   - pip
   - psutil=5.7
   - py-xgboost=0.90
   - pydot=1.4
-  - pyglet=1.5
   - pyopengl=3.1
-  - python=3.7
   - python-graphviz
+  - python=3.7
   #- pyvirtualdisplay=0.2 # add if on headless server
-  - requests=2.22
   - scikit-image=0.16
-  - scikit-learn=0.22
-  - scipy=1.4
-  - tqdm=4.43
   - wheel
   - widgetsnbextension=3.5
+  - widgetsnbextension=3.5
   - pip:
-    - atari-py==0.2.6
-    - ftfy==5.7
-    - gast==0.2.2
-    - gym==0.17.1
-    - opencv-python==4.2.0.32
-    - spacy==2.2.4
-    - tensorboard==2.1.1
-    - tensorflow-addons==0.8.3
-    - tensorflow-data-validation==0.21.5
-    - tensorflow-datasets==2.1.0
-    - tensorflow-estimator==2.1.0
-    - tensorflow-hub==0.7.0
-    - tensorflow-metadata==0.21.1
-    - tensorflow-model-analysis==0.21.6
-    - tensorflow-probability==0.9.0
-    - tensorflow-serving-api==2.1.0 # or tensorflow-serving-api-gpu if gpu
-    - tensorflow-transform==0.21.2
-    - tensorflow==2.1.0 # or tensorflow-gpu if gpu
-    - tf-agents==0.3.0
-    - tfx==0.21.2
-    - transformers==2.8.0
-    - urlextract==0.14.0
+    - -r file:requirements.txt

--- a/requirements.txt
+++ b/requirements.txt
@@ -2,13 +2,13 @@
 # on Windows or when using a GPU. Please see the installation
 # instructions in INSTALL.md
 
-
 ##### Core scientific packages
 jupyter==1.0.0
 matplotlib==3.3.2
 numpy==1.18.5
 pandas==1.1.3
 scipy==1.5.3
+spacy==2.2.4
 
 ##### Machine Learning packages
 scikit-learn==0.23.2
@@ -31,11 +31,16 @@ tensorflow==2.3.1
 # Optional: the TF Serving API library is just needed for chapter 19.
 tensorflow-serving-api==2.3.0 # or tensorflow-serving-api-gpu if gpu
 
-tensorboard==2.3.0
 tensorboard-plugin-profile==2.3.0
+tensorboard==2.3.0
+tensorflow-data-validation==0.21.5
 tensorflow-datasets==4.0.1
+tensorflow-estimator==2.1.0
 tensorflow-hub==0.9.0
+tensorflow-metadata==0.21.1
+tensorflow-model-analysis==0.21.6
 tensorflow-probability==0.11.1
+tensorflow-transform==0.21.2
 
 # Optional: only used in chapter 13.
 # NOT AVAILABLE ON WINDOWS
@@ -53,13 +58,14 @@ gym[atari]==0.17.3
 # On Windows, install atari_py using:
 # pip install --no-index -f https://github.com/Kojoley/atari-py/releases atari_py
 
+atari-py==0.2.6
 tf-agents==0.6.0
 
 ##### Image manipulation
 Pillow==8.0.0
 graphviz==0.14.2
 opencv-python==4.4.0.44
-pyglet==1.4.11
+pyglet==1.5
 
 #pyvirtualdisplay # needed in chapter 16, if on a headless server
                   # (i.e., without screen, e.g., Colab or VM)
@@ -90,13 +96,3 @@ ftfy==5.8
 
 # Optional: tqdm displays nice progress bars, ipywidgets for tqdm's notebook support
 tqdm==4.50.2
-ipywidgets==7.5.1
-
-
-
-# Specific lib versions to avoid conflicts
-attrs==19.3.0
-cloudpickle==1.3.0
-dill==0.3.1.1
-gast==0.3.3
-httplib2==0.17.4


### PR DESCRIPTION
Closes #327 

Duplicate packages have been removed, keeping with the latest version of
the package.

pip dependencies have been moved to a single `requirements.txt` file

Closes https://github.com/tallamjr/handson-ml2/issues/1

	modified:   environment.yml
	modified:   requirements.txt