### PR TITLE
Fixed compatibility issue for scikit-learn 0.24

### DIFF
--- a/03_classification.ipynb
+++ b/03_classification.ipynb
@@ -102,7 +102,7 @@
    ],
    "source": [
     "from sklearn.datasets import fetch_openml\n",
-    "mnist = fetch_openml('mnist_784', version=1)\n",
+    "mnist = fetch_openml('mnist_784', version=1, as_frame=False)\n",
     "mnist.keys()"
    ]
   },

--- a/05_support_vector_machines.ipynb
+++ b/05_support_vector_machines.ipynb
@@ -2038,7 +2038,7 @@
    "outputs": [],
    "source": [
     "from sklearn.datasets import fetch_openml\n",
-    "mnist = fetch_openml('mnist_784', version=1, cache=True)\n",
+    "mnist = fetch_openml('mnist_784', version=1, cache=True, as_frame=False)\n",
     "\n",
     "X = mnist[\"data\"]\n",
     "y = mnist[\"target\"].astype(np.uint8)\n",

--- a/07_ensemble_learning_and_random_forests.ipynb
+++ b/07_ensemble_learning_and_random_forests.ipynb
@@ -1018,7 +1018,7 @@
    "source": [
     "from sklearn.datasets import fetch_openml\n",
     "\n",
-    "mnist = fetch_openml('mnist_784', version=1)\n",
+    "mnist = fetch_openml('mnist_784', version=1, as_frame=False)\n",
     "mnist.target = mnist.target.astype(np.uint8)"
    ]
   },

--- a/08_dimensionality_reduction.ipynb
+++ b/08_dimensionality_reduction.ipynb
@@ -1092,7 +1092,7 @@
    "source": [
     "from sklearn.datasets import fetch_openml\n",
     "\n",
-    "mnist = fetch_openml('mnist_784', version=1)\n",
+    "mnist = fetch_openml('mnist_784', version=1, as_frame=False)\n",
     "mnist.target = mnist.target.astype(np.uint8)"
    ]
   },

--- a/09_unsupervised_learning.ipynb
+++ b/09_unsupervised_learning.ipynb
@@ -1330,7 +1330,7 @@
     "import urllib\n",
     "from sklearn.datasets import fetch_openml\n",
     "\n",
-    "mnist = fetch_openml('mnist_784', version=1)\n",
+    "mnist = fetch_openml('mnist_784', version=1, as_frame=False)\n",
     "mnist.target = mnist.target.astype(np.int64)"
    ]
   },


### PR DESCRIPTION
Fixed an issue where the dataset would be loaded as a pandas dataframe instead of a numpy array when using scikit-learn 0.24. In this version, the `as_frame` argument for `fetch_openml` is no longer set to `False` by default. (See issue #352)