### PR TITLE
Import urllib.request instead of urllib

### DIFF
--- a/01_the_machine_learning_landscape.ipynb
+++ b/01_the_machine_learning_landscape.ipynb
@@ -133,7 +133,7 @@
    ],
    "source": [
     "# Download the data\n",
-    "import urllib\n",
+    "import urllib.request\n",
     "DOWNLOAD_ROOT = \"https://raw.githubusercontent.com/ageron/handson-ml2/master/\"\n",
     "os.makedirs(datapath, exist_ok=True)\n",
     "for filename in (\"oecd_bli_2015.csv\", \"gdp_per_capita.csv\"):\n",

--- a/02_end_to_end_machine_learning_project.ipynb
+++ b/02_end_to_end_machine_learning_project.ipynb
@@ -95,7 +95,7 @@
    "source": [
     "import os\n",
     "import tarfile\n",
-    "import urllib\n",
+    "import urllib.request\n",
     "\n",
     "DOWNLOAD_ROOT = \"https://raw.githubusercontent.com/ageron/handson-ml2/master/\"\n",
     "HOUSING_PATH = os.path.join(\"datasets\", \"housing\")\n",

--- a/03_classification.ipynb
+++ b/03_classification.ipynb
@@ -3571,7 +3571,7 @@
    "source": [
     "import os\n",
     "import tarfile\n",
-    "import urllib\n",
+    "import urllib.request\n",
     "\n",
     "DOWNLOAD_ROOT = \"http://spamassassin.apache.org/old/publiccorpus/\"\n",
     "HAM_URL = DOWNLOAD_ROOT + \"20030228_easy_ham.tar.bz2\"\n",

--- a/09_unsupervised_learning.ipynb
+++ b/09_unsupervised_learning.ipynb
@@ -1327,7 +1327,7 @@
    "metadata": {},
    "outputs": [],
    "source": [
-    "import urllib\n",
+    "import urllib.request\n",
     "from sklearn.datasets import fetch_openml\n",
     "\n",
     "mnist = fetch_openml('mnist_784', version=1)\n",

--- a/13_loading_and_preprocessing_data.ipynb
+++ b/13_loading_and_preprocessing_data.ipynb
@@ -2363,7 +2363,7 @@
    "source": [
     "import os\n",
     "import tarfile\n",
-    "import urllib\n",
+    "import urllib.request\n",
     "\n",
     "DOWNLOAD_ROOT = \"https://raw.githubusercontent.com/ageron/handson-ml2/master/\"\n",
     "HOUSING_PATH = os.path.join(\"datasets\", \"housing\")\n",


### PR DESCRIPTION
As of January 25, 2021, in some environments, such as Colab (Python 3.6.9),
the following import statement
    import urllib
is not the right one for using urllib.request.

Indeed, calls to urllib.request functions then yield the following error:
    AttributeError: module 'urllib' has no attribute 'request'

One must import urllib.request instead.

See also https://stackoverflow.com/q/22278993