### PR TITLE
Fixes Chapter 3 MNIST get data from X[0] error

### DIFF
--- a/03_classification.ipynb
+++ b/03_classification.ipynb
@@ -197,7 +197,7 @@
     "import matplotlib as mpl\n",
     "import matplotlib.pyplot as plt\n",
     "\n",
-    "some_digit = X[0]\n",
+    "some_digit=np.array(X.iloc[0])\n",
     "some_digit_image = some_digit.reshape(28, 28)\n",
     "plt.imshow(some_digit_image, cmap=mpl.cm.binary)\n",
     "plt.axis(\"off\")\n",
@@ -4582,7 +4582,7 @@
    "name": "python",
    "nbconvert_exporter": "python",
    "pygments_lexer": "ipython3",
-   "version": "3.7.8"
+   "version": "3.7.10"
   },
   "nav_menu": {},
   "toc": {


### PR DESCRIPTION
In Chapter 3,

```
%matplotlib inline
import matplotlib as mpl
import matplotlib.pyplot as plt

some_digit = X[0]
some_digit_image = some_digit.reshape(28, 28)
plt.imshow(some_digit_image, cmap=mpl.cm.binary)
plt.axis("off")

save_fig("some_digit_plot")
plt.show()

```
Making with the above code and it raised error:

```
---------------------------------------------------------------------------
KeyError                                  Traceback (most recent call last)
~/anaconda3/envs/tf2/lib/python3.7/site-packages/pandas/core/indexes/base.py in get_loc(self, key, method, tolerance)
   3079             try:
-> 3080                 return self._engine.get_loc(casted_key)
   3081             except KeyError as err:

pandas/_libs/index.pyx in pandas._libs.index.IndexEngine.get_loc()

pandas/_libs/index.pyx in pandas._libs.index.IndexEngine.get_loc()

pandas/_libs/hashtable_class_helper.pxi in pandas._libs.hashtable.PyObjectHashTable.get_item()

pandas/_libs/hashtable_class_helper.pxi in pandas._libs.hashtable.PyObjectHashTable.get_item()

KeyError: 0

The above exception was the direct cause of the following exception:

KeyError                                  Traceback (most recent call last)
<ipython-input-6-29a4c649ca11> in <module>
      3 import matplotlib.pyplot as plt
      4 
----> 5 some_digit = X[0]
      6 #some_digit=np.array(X.iloc[0])
      7 some_digit_image = some_digit.reshape(28, 28)

~/anaconda3/envs/tf2/lib/python3.7/site-packages/pandas/core/frame.py in __getitem__(self, key)
   3022             if self.columns.nlevels > 1:
   3023                 return self._getitem_multilevel(key)
-> 3024             indexer = self.columns.get_loc(key)
   3025             if is_integer(indexer):
   3026                 indexer = [indexer]

~/anaconda3/envs/tf2/lib/python3.7/site-packages/pandas/core/indexes/base.py in get_loc(self, key, method, tolerance)
   3080                 return self._engine.get_loc(casted_key)
   3081             except KeyError as err:
-> 3082                 raise KeyError(key) from err
   3083 
   3084         if tolerance is not None:

KeyError: 0
```
