### PR TITLE
very minor change on greedy policy variable usage

### DIFF
--- a/18_reinforcement_learning.ipynb
+++ b/18_reinforcement_learning.ipynb
@@ -1597,7 +1597,7 @@
    "source": [
     "def epsilon_greedy_policy(state, epsilon=0):\n",
     "    if np.random.rand() < epsilon:\n",
-    "        return np.random.randint(2)\n",
+    "        return np.random.randint(n_outputs)\n",
     "    else:\n",
     "        Q_values = model.predict(state[np.newaxis])\n",
     "        return np.argmax(Q_values[0])"


### PR DESCRIPTION
Chap 18, why not using directly the 'n_outputs' variable defined earlier, instead of hardcoded '2'