### PR TITLE
Updated 03_classification.ipynb

### DIFF
--- a/03_classification.ipynb
+++ b/03_classification.ipynb
@@ -768,7 +768,7 @@
    "metadata": {},
    "outputs": [],
    "source": [
-    "y_scores = cross_val_predict(sgd_clf, X_train, y_train_5, cv=3,\n",
+    "y_scores = cross_val_predict(sgd_clf, X_train, y_train_5.ravel(), cv=3,\r\n",
     "                             method=\"decision_function\")"
    ]
   },


### PR DESCRIPTION
Fixed error at cross_val_predict. Without ravel it took inconsistent size types and was throwing an error.