### PR TITLE
Fixed typos in linear algebra tutorial

### DIFF
--- a/math_linear_algebra.ipynb
+++ b/math_linear_algebra.ipynb
@@ -2615,7 +2615,7 @@
    "cell_type": "markdown",
    "metadata": {},
    "source": [
-    "This quite explicit: we are asking for a new vertical axis, keeping the existing data as the horizontal axis."
+    "This is quite explicit: we are asking for a new vertical axis, keeping the existing data as the horizontal axis."
    ]
   },
   {
@@ -2730,7 +2730,7 @@
    "metadata": {},
    "source": [
     "## Plotting a matrix\n",
-    "We have already seen that vectors can been represented as points or arrows in N-dimensional space. Is there a good graphical representation of matrices? Well you can simply see a matrix as a list of vectors, so plotting a matrix results in many points or arrows. For example, let's create a $2 \\times 4$ matrix `P` and plot it as points:"
+    "We have already seen that vectors can be represented as points or arrows in N-dimensional space. Is there a good graphical representation of matrices? Well you can simply see a matrix as a list of vectors, so plotting a matrix results in many points or arrows. For example, let's create a $2 \\times 4$ matrix `P` and plot it as points:"
    ]
   },
   {
@@ -4566,7 +4566,7 @@
    "name": "python",
    "nbconvert_exporter": "python",
    "pygments_lexer": "ipython3",
-   "version": "3.7.9"
+   "version": "3.8.5"
   },
   "toc": {
    "toc_cell": false,


### PR DESCRIPTION
This is the fix to two small typos in linear algebra notebook.