### PR TITLE
[Typo] Fix typo in Chapter 9 Olivetti faces exercise

### DIFF
--- a/09_unsupervised_learning.ipynb
+++ b/09_unsupervised_learning.ipynb
@@ -5336,7 +5336,7 @@
    "cell_type": "markdown",
    "metadata": {},
    "source": [
-    "The optimal number of clusters is not clear on this inertia diagram, as there is no obvious elbow, so let's stick with k=100."
+    "The optimal number of clusters is not clear on this inertia diagram, as there is no obvious elbow, so let's stick with k=120."
    ]
   },
   {


### PR DESCRIPTION
Fixing minor typo in Chapter 9 Olivetti faces exercise. Since the best `k` for this example is 120, `k=100` should be `k=120`
![image](https://user-images.githubusercontent.com/4649835/130375020-b5d51dcc-1891-4843-9bd3-4d31008e7d5f.png)
