### PR TITLE
Fix typos in Chapter 5 Exercise 9

### DIFF
--- a/05_support_vector_machines.ipynb
+++ b/05_support_vector_machines.ipynb
@@ -2235,7 +2235,7 @@
    "cell_type": "markdown",
    "metadata": {},
    "source": [
-    "Okay, 89.5% accuracy on MNIST is pretty bad. This linear model is certainly too simple for MNIST, but perhaps we just needed to scale the data first:"
+    "Okay, 83.5% accuracy on MNIST is pretty bad. This linear model is certainly too simple for MNIST, but perhaps we just needed to scale the data first:"
    ]
   },
   {
@@ -2310,7 +2310,7 @@
    "cell_type": "markdown",
    "metadata": {},
    "source": [
-    "That's much better (we cut the error rate by about 25%), but still not great at all for MNIST. If we want to use an SVM, we will have to use a kernel. Let's try an `SVC` with an RBF kernel (the default)."
+    "That's much better (we cut the error rate by about 53%), but still not great at all for MNIST. If we want to use an SVM, we will have to use a kernel. Let's try an `SVC` with an RBF kernel (the default)."
    ]
   },
   {


### PR DESCRIPTION
This PR fixes two typos in the commentary for Exercise 9 of Chapter 5.

1. The accuracy calculated in cell 49 is 83.5%.
2. The percent change in the error rate of 25% references the incorrect value of 89.5%. That is, ((1 - 0.895) - (1 - 0.9217)) / (1 - 0.895) * 100 = 25%. The percent change should be ((1 - 0.835) - (1 - 0.9217)) / (1 - 0.835) * 100 = 53%.