### PR TITLE
Changes in chapter 7

### DIFF
--- a/07_ensemble_learning_and_random_forests.ipynb
+++ b/07_ensemble_learning_and_random_forests.ipynb
@@ -441,7 +441,7 @@
     }
    ],
    "source": [
-    "fix, axes = plt.subplots(ncols=2, figsize=(10,4), sharey=True)\n",
+    "fig, axes = plt.subplots(ncols=2, figsize=(10,4), sharey=True)\n",
     "plt.sca(axes[0])\n",
     "plot_decision_boundary(tree_clf, X, y)\n",
     "plt.title(\"Decision Tree\", fontsize=14)\n",

--- a/07_ensemble_learning_and_random_forests.ipynb
+++ b/07_ensemble_learning_and_random_forests.ipynb
@@ -1683,7 +1683,7 @@
     "plt.figure(figsize=(10, 4))\n",
     "\n",
     "plt.subplot(121)\n",
-    "plt.plot(errors, \"b.-\")\n",
+    "plt.plot(np.arange(1, len(errors) + 1), errors, \"b.-\")\n",
     "plt.plot([bst_n_estimators, bst_n_estimators], [0, min_error], \"k--\")\n",
     "plt.plot([0, 120], [min_error, min_error], \"k--\")\n",
     "plt.plot(bst_n_estimators, min_error, \"ko\")\n",


### PR DESCRIPTION
This PR makes two minor changes to the Chapter 7 notebook.

In cell 44, the `bst_n_estimators` (number of trees) calculation accounts for the 0-index based array `errors`. This is neglected in cell 46, resulting in an off-by-one error.

In cell 46, if the limits of the axes are set as `plt.axis([50, 60, 0.00270, 0.00275])` and if the line `plt.text(bst_n_estimators, min_error*1.2, "Minimum", ha="center", fontsize=14)` is commented out, then the plots below show the difference before and after the PR.

The off-by-one error may have been intentional, in the sense that it doesn't really affect the purpose of the figure in the book with the zoomed-out limits of the axes. If that is the case, please let me know and I'll modify the pull request.

**Before the PR:**


![early_stopping_gbrt_plot_before](https://user-images.githubusercontent.com/89653229/151566711-ad956fef-d9b0-4e8a-96b1-b1fc50eadeb7.png)


**After the PR:**


![early_stopping_gbrt_plot_after](https://user-images.githubusercontent.com/89653229/151566744-0470534e-4ee7-4602-af80-2d9b2bf90a35.png)