### PR TITLE
Added Windows support

### DIFF
--- a/19_training_and_deploying_at_scale.ipynb
+++ b/19_training_and_deploying_at_scale.ipynb
@@ -240,7 +240,10 @@
    "metadata": {},
    "outputs": [],
    "source": [
-    "!rm -rf {model_name}"
+    "#On Linux\n",
+    "!rm -rf {model_name}\n",
+    "#On Windows\n",
+    "#!rd /s /q \"my_mnist_model\""
    ]
   },
   {


### PR DESCRIPTION
`!rm -rf {model_name}` only works on Linux by default, I have added a support for Windows.