### PR TITLE
Change tol=-np.infty to tol=None in SGDRegressor

### DIFF
--- a/04_training_linear_models.ipynb
+++ b/04_training_linear_models.ipynb
@@ -1380,7 +1380,7 @@
     "X_train_poly_scaled = poly_scaler.fit_transform(X_train)\n",
     "X_val_poly_scaled = poly_scaler.transform(X_val)\n",
     "\n",
-    "sgd_reg = SGDRegressor(max_iter=1, tol=-np.infty, warm_start=True,\n",
+    "sgd_reg = SGDRegressor(max_iter=1, tol=None, warm_start=True,\n",
     "                       penalty=None, learning_rate=\"constant\", eta0=0.0005, random_state=42)\n",
     "\n",
     "minimum_val_error = float(\"inf\")\n",
@@ -1429,7 +1429,7 @@
     }
    ],
    "source": [
-    "sgd_reg = SGDRegressor(max_iter=1, tol=-np.infty, warm_start=True,\n",
+    "sgd_reg = SGDRegressor(max_iter=1, tol=None, warm_start=True,\n",
     "                       penalty=None, learning_rate=\"constant\", eta0=0.0005, random_state=42)\n",
     "\n",
     "n_epochs = 500\n",


### PR DESCRIPTION
Hi @ageron,
In Scikit-learn 1.2, type hint for mypy is added(https://github.com/scikit-learn/scikit-learn/pull/24301).
Recently Colab updated sklearn to 1.2.1 and `tol=-np.infty` raise an error.
So it must be changed `tol=None`(it actually means `tol=-np.inf`).
Thank you!