### PR TITLE
Fix deprecation warning by updating import of shift from scipy.ndimage

### DIFF
--- a/03_classification.ipynb
+++ b/03_classification.ipynb
@@ -1961,7 +1961,7 @@
     }
    ],
    "source": [
-    "from scipy.ndimage.interpolation import shift\n",
+    "from scipy.ndimage import shift\n",
     "def shift_digit(digit_array, dx, dy, new=0):\n",
     "    return shift(digit_array.reshape(28, 28), [dy, dx], cval=new).reshape(784)\n",
     "\n",
@@ -2329,7 +2329,7 @@
    "metadata": {},
    "outputs": [],
    "source": [
-    "from scipy.ndimage.interpolation import shift"
+    "from scipy.ndimage import shift"
    ]
   },
   {


### PR DESCRIPTION
Fixes deprecation warning by updating shift import from scipy.ndimage.interpolation to scipy.ndimage
![image](https://github.com/user-attachments/assets/b73aa5c9-e10a-4c99-bdb2-faeafdaf15f9)
