### PR TITLE
fixed deprecated sparse argument

### DIFF
--- a/03_classification.ipynb
+++ b/03_classification.ipynb
@@ -3122,7 +3122,7 @@
    "source": [
     "cat_pipeline = Pipeline([\n",
     "        (\"imputer\", SimpleImputer(strategy=\"most_frequent\")),\n",
-    "        (\"cat_encoder\", OneHotEncoder(sparse=False)),\n",
+    "        (\"cat_encoder\", OneHotEncoder(sparse_output=False)),\n",
     "    ])"
    ]
   },


### PR DESCRIPTION
fixed deprecated sparse argument in OneHotEncoder (chapter 3),  replacing it with spare_output (deprecated since sickit-learn 1.2 and removed in 1.4)
![image](https://github.com/user-attachments/assets/709b8572-1869-4fdc-9333-006b3e49609d)
