### PR TITLE
  Fix conda env create failures on modern conda/pip

### DIFF
--- a/INSTALL.md
+++ b/INSTALL.md
@@ -37,6 +37,11 @@ Next, activate the new environment:
 
     $ conda activate tf2
 
+If `conda env create` crashes with `PermissionError: [Errno 13]` in CUDA/plugin detection or cannot write to conda cache files, retry with:
+
+    $ mkdir -p .cache
+    $ XDG_CACHE_HOME=$PWD/.cache CONDA_OVERRIDE_CUDA='' conda env create -f environment.yml
+
 
 ## Start Jupyter
 You're almost there! You just need to register the `tf2` conda environment to Jupyter. The notebooks in this project will default to the environment named `python3`, so it's best to register this environment using the name `python3` (if you prefer to use another name, you will have to select it in the "Kernel > Change kernel..." menu in Jupyter every time you open a notebook):

--- a/environment.yml
+++ b/environment.yml
@@ -18,7 +18,7 @@ dependencies:
   - opencv=4.5  # used only in chapter 18 by TF Agents for image preprocessing
   - pandas=1.3  # data analysis and manipulation tool
   - pillow=8.3  # image manipulation library, (used by matplotlib.image.imread)
-  - pip  # Python's package-management system
+  - pip=23.3  # keep pip <24 for gym 0.21 build compatibility
   - py-xgboost=1.4  # used only in chapter 7 for optimized Gradient Boosting
   - pyglet=1.5  # used only in chapter 18 to render environments
   - pyopengl=3.1  # used only in chapter 18 to render environments
@@ -29,7 +29,7 @@ dependencies:
   - scikit-learn=1.0  # machine learning library
   - scipy=1.7  # scientific/technical computing library
   - tqdm=4.62  # a progress bar library
-  - wheel  # built-package format for pip
+  - wheel=0.37  # newer wheel rejects gym 0.21 legacy metadata
   - widgetsnbextension=3.5  # interactive HTML widgets for Jupyter notebooks
   - pip:
     - tensorboard-plugin-profile~=2.5.0  # profiling plugin for TensorBoard


### PR DESCRIPTION
### Summary
  This PR fixes environment creation issues reported when running:

  ```conda env create -f environment.yml```

 ### Changes

  - Pin `pip` to `23.3` in `environment.yml`
  - Pin `wheel` to `0.37` in `environment.yml`
  - Add troubleshooting note in INSTALL.md for conda CUDA/cache permission issues using:
      - `XDG_CACHE_HOME=$PWD/.cache CONDA_OVERRIDE_CUDA=''`

### Root cause

  - gym==0.21.0 (installed via pip extras) fails to build with newer wheel versions because of legacy requirement metadata parsing.
  - Some conda setups also crash during CUDA virtual package detection/cache access.

 ### Validation

  - Recreated tf2 environment successfully end-to-end with updated files.